### PR TITLE
Don't compile BlurHashView when targeting watchOS

### DIFF
--- a/Sources/BlurHashKit/BlurHashView.swift
+++ b/Sources/BlurHashKit/BlurHashView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if !os(watchOS)
 public struct BlurHashView: UIViewRepresentable {
 
     private let blurHash: String
@@ -68,3 +69,4 @@ public class UIBlurHashImageView: UIImageView {
         }
     }
 }
+#endif


### PR DESCRIPTION
BlurHashView references UIViewRepresentable, which is not available in watchOS.